### PR TITLE
Go script to update usb0 and usb1 addresses.  

### DIFF
--- a/debian/install
+++ b/debian/install
@@ -2,4 +2,5 @@ etc/systemd/network/usb0.network etc/systemd/network/
 etc/systemd/network/usb1.network etc/systemd/network/
 etc/systemd/system/usb-gadget.service etc/systemd/system/
 usr/bin/usb_otg_setup.sh usr/bin/
+usr/bin/usb_update_address.sh usr/bin/
 

--- a/etc/systemd/network/usb0.network
+++ b/etc/systemd/network/usb0.network
@@ -7,7 +7,7 @@ Scope=link
 
 [Network]
 DHCPServer=yes
-LinkLocalAddressing=yes
+LinkLocalAddressing=no
 IPv6AcceptRA=no
 
 [DHCPServer]

--- a/etc/systemd/network/usb1.network
+++ b/etc/systemd/network/usb1.network
@@ -7,7 +7,7 @@ Scope=link
 
 [Network]
 DHCPServer=yes
-LinkLocalAddressing=yes
+LinkLocalAddressing=no
 IPv6AcceptRA=no
 
 [DHCPServer]

--- a/usr/bin/usb_update_address.sh
+++ b/usr/bin/usb_update_address.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+#
+# Usage:
+#   sudo ./usb_update_address.sh <new_cidr>
+#
+# Example:
+#   sudo ./usb_update_address.sh 10.43.0.1/24
+#
+# This script updates the Address line in usb0.network and usb1.network,
+# then restarts.
+#
+set -e
+#set -x
+
+if [ -z "$1" ]; then
+  echo "Usage: $0 <new_cidr>"
+  echo "Example: $0 10.43.0.1/24"
+  exit 1
+fi
+
+NEW_CIDR="$1"
+
+# Adjust these paths if necessary
+USB0_NETWORK_FILE="/etc/systemd/network/usb0.network"
+USB1_NETWORK_FILE="/etc/systemd/network/usb1.network"
+
+# Backup existing .network files
+cp -v "$USB0_NETWORK_FILE" "${USB0_NETWORK_FILE}.bak"
+cp -v "$USB1_NETWORK_FILE" "${USB1_NETWORK_FILE}.bak"
+
+# Update the Address line in each file
+sed -i "s|^Address=.*|Address=$NEW_CIDR|g" "$USB0_NETWORK_FILE"
+sed -i "s|^Address=.*|Address=$NEW_CIDR|g" "$USB1_NETWORK_FILE"
+
+shutdown -r now
+echo "Rebooting..."


### PR DESCRIPTION
## Type of change 
* [X] New feature (non-breaking change adding functionality)

## Breaking change
No

## Proposed change
Needed a simple way to update address of usb0 and usb1 simultaneously.  This is useful when using multiple Go devices simultaneously.

## Testing
Verified that it changed the address as expected.

## Checklist
* [X] I have read the [contribution guidelines and policies](https://github.com/WLAN-Pi/.github/blob/main/docs/contributing.md)
* [X] I have targeted this PR against the correct git branch (this can vary depending on the default branch of the repo)
* [x] I linked a GitHub issue to this PR (in the next section). 

## Related Issues/PRs
- This PR fixes/closes issue #4 