### PR TITLE
Removed extra link-local address on usb0 and usb1 interfaces

### DIFF
--- a/etc/systemd/network/usb0.network
+++ b/etc/systemd/network/usb0.network
@@ -7,7 +7,7 @@ Scope=link
 
 [Network]
 DHCPServer=yes
-LinkLocalAddressing=yes
+LinkLocalAddressing=no
 IPv6AcceptRA=no
 
 [DHCPServer]

--- a/etc/systemd/network/usb1.network
+++ b/etc/systemd/network/usb1.network
@@ -7,7 +7,7 @@ Scope=link
 
 [Network]
 DHCPServer=yes
-LinkLocalAddressing=yes
+LinkLocalAddressing=no
 IPv6AcceptRA=no
 
 [DHCPServer]


### PR DESCRIPTION
## Type of change 
* [X] Bug fix (non-breaking change that fixes something)

## Breaking change
No

## Proposed change
Changed LinkLocalAddressing=yes to LinkLocalAddressing=no in the following files ::
/etc/systemd/network/usb0.network
/etc/systemd/network/usb1.network

## Testing
Did not test when connecting Go to Mac but it should yield the same results.

wlanpi@wlanpi-ff5:~ $ ip addr
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000
link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
inet 127.0.0.1/8 scope host lo
valid_lft forever preferred_lft forever
inet6 ::1/128 scope host noprefixroute
valid_lft forever preferred_lft forever
2: eth0: <BROADCAST,MULTICAST> mtu 1500 qdisc noop state DOWN group default qlen 1000
link/ether 2c:cf:67:6f:ff:f5 brd ff:ff:ff:ff:ff:ff
3: usb0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc pfifo_fast state DOWN group default qlen 1000
link/ether 02:00:00:c0:66:02 brd ff:ff:ff:ff:ff:ff
4: usb1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP group default qlen 1000
link/ether 02:00:00:c0:66:02 brd ff:ff:ff:ff:ff:ff
inet 10.42.0.1/24 brd 10.42.0.255 scope link usb1
valid_lft forever preferred_lft forever

motd output ::
Network interfaces:
usb1 10.42.0.1

## Checklist
* [X] I have read the [contribution guidelines and policies](https://github.com/WLAN-Pi/.github/blob/main/docs/contributing.md)
* [X] I have targeted this PR against the correct git branch (this can vary depending on the default branch of the repo)
* [X] I linked a GitHub issue to this PR (in the next section). 

## Related Issues/PRs
- This PR fixes/closes issue #2 