### PR TITLE
Removed usb1 keepalive (for Windows as it recovers properly)

### DIFF
--- a/usr/bin/usb-ethernet-gadget.sh
+++ b/usr/bin/usb-ethernet-gadget.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Configuration
-INTERFACES=("usb0" "usb1") # USB Ethernet interfaces to monitor
+INTERFACES=("usb0") # USB Ethernet interfaces to monitor
 LOG_FILE="/var/log/usb-ethernet-gadget.log"
 STATE_FILE="/var/run/usb-ethernet-gadget.state"
 CHECK_INTERVAL=10          # Seconds between keep-alive checks


### PR DESCRIPTION
## Type of change 
* [x] Bug fix (non-breaking change that fixes something)

## Breaking change
No

## Proposed change
Remove usb1 from keepalive

## Testing
Confirmed fix on Windows.  Does not effect other platforms (usb0=linux/Mac/iOS)

## Checklist
* [x] I have read the [contribution guidelines and policies](https://github.com/WLAN-Pi/.github/blob/main/docs/contributing.md)
* [x] I have targeted this PR against the correct git branch (this can vary depending on the default branch of the repo)
* [x] I linked a GitHub issue to this PR (in the next section). 

## Related Issues/PRs
- This PR fixes/closes issue #10 