### PR TITLE
Add packagecloud deploy workflow and bump to 1.5.1 for trixie

### DIFF
--- a/.github/workflows/deploy-to-packagecloud.yml
+++ b/.github/workflows/deploy-to-packagecloud.yml
@@ -1,0 +1,64 @@
+name: Deploy to Packagecloud
+
+on:
+  # Allow manual runs of workflow from Actions tab
+  workflow_dispatch:
+
+  push:
+    branches:
+      - main
+    paths:
+      - 'debian/changelog'
+
+jobs:
+  sbuild:
+    name: sbuild ${{ matrix.distro }}+${{ matrix.arch }}
+
+    runs-on: 'ubuntu-24.04-arm'
+
+    strategy:
+      fail-fast: false
+      matrix:
+        distro: [bookworm, trixie]
+        arch: [arm64]
+
+    environment: PACKAGECLOUD
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: sbuild for ${{ matrix.distro }} ${{ matrix.arch }}
+        uses: wlan-pi/sbuild-debian-package@main
+        id: build-debian-package
+        with:
+          distro: ${{ matrix.distro }}
+          arch: ${{ matrix.arch }}
+
+      - name: Archive artifacts and upload to GitHub
+        uses: actions/upload-artifact@v4
+        with:
+          name: wlanpi-usb-ethernet-${{ matrix.distro }}-${{ matrix.arch }}
+          path: ${{ steps.build-debian-package.outputs.deb-package }}
+
+      - name: Upload arm64 package to debian/${{ matrix.distro }}
+        uses: danielmundi/upload-packagecloud@main
+        with:
+          package-name: ${{ steps.build-debian-package.outputs.deb-package }}
+          packagecloud-username: wlanpi
+          packagecloud-repo: dev
+          packagecloud-distrib: debian/${{ matrix.distro }}
+          packagecloud-token: ${{ secrets.PACKAGECLOUD_TOKEN }}
+
+  slack-workflow-status:
+    if: always()
+    name: Post Workflow Status to Slack
+    needs:
+      - sbuild
+    runs-on: 'ubuntu-24.04-arm'
+    steps:
+      - name: Slack Workflow Notification
+        uses: Gamesight/slack-workflow-status@master
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wlanpi-usb-ethernet (1.5.1) bookworm; urgency=medium
+
+  * Rebuild to publish packages for Debian trixie to packagecloud
+
+ -- Josh Schmelzle <josh@joshschmelzle.com>  Thu, 09 Jul 2026 23:03:04 -0400
+
 wlanpi-usb-ethernet (1.5.0) bookworm; urgency=medium
 
   * Add sleep/wake cycle detection using USB suspend flags


### PR DESCRIPTION
Unlike its sibling repos, this repo had no packagecloud deploy workflow. The bookworm package on packagecloud was presumably pushed manually. This PR:

- Adds `deploy-to-packagecloud.yml` modeled on wlanpi-shell-config: sbuild for bookworm + trixie (arm64) via wlan-pi/sbuild-debian-package, upload to packagecloud wlanpi/dev, triggered by changelog changes on main or manual dispatch.
- Bumps the changelog to 1.5.1 so merging triggers the first deploy.

Notes:
- The repo may need the `PACKAGECLOUD` environment / `PACKAGECLOUD_TOKEN` secret configured if it isn't inherited from the org.
- After merge, verify the package actually appears in https://packagecloud.io/wlanpi/dev/debian/dists/trixie/main/binary-arm64/Packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)