### PR TITLE
Update actions to current majors; verify packagecloud pushes

### DIFF
--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -42,7 +42,7 @@ jobs:
 
       # 2) Check out repository (for manual runs, checkout the specified branch).
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.branch || github.ref }}
 
@@ -89,7 +89,7 @@ jobs:
 
       # 6) Upload artifact
       - name: Upload Debian package
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           # The artifact name includes the generated version (with the branch)
           name: wlanpi-usb-ethernet_${{ env.new_version }}

--- a/.github/workflows/deploy-to-packagecloud.yml
+++ b/.github/workflows/deploy-to-packagecloud.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: sbuild for ${{ matrix.distro }} ${{ matrix.arch }}
         uses: wlan-pi/sbuild-debian-package@main
@@ -36,19 +36,32 @@ jobs:
           arch: ${{ matrix.arch }}
 
       - name: Archive artifacts and upload to GitHub
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wlanpi-usb-ethernet-${{ matrix.distro }}-${{ matrix.arch }}
           path: ${{ steps.build-debian-package.outputs.deb-package }}
 
-      - name: Upload arm64 package to debian/${{ matrix.distro }}
-        uses: danielmundi/upload-packagecloud@main
-        with:
-          package-name: ${{ steps.build-debian-package.outputs.deb-package }}
-          packagecloud-username: wlanpi
-          packagecloud-repo: dev
-          packagecloud-distrib: debian/${{ matrix.distro }}
-          packagecloud-token: ${{ secrets.PACKAGECLOUD_TOKEN }}
+      # Push with the package_cloud CLI directly instead of an action so upload
+      # errors are detected: the CLI exits 0 even when a push fails (Thor bug),
+      # which has produced green runs that uploaded nothing.
+      - name: Upload package to packagecloud ${{ matrix.distro }}
+        env:
+          PACKAGECLOUD_TOKEN: ${{ secrets.PACKAGECLOUD_TOKEN }}
+          DEB_PACKAGE: ${{ steps.build-debian-package.outputs.deb-package }}
+        run: |
+          if [ -z "${DEB_PACKAGE}" ]; then
+            echo "::error::sbuild produced no .deb package"
+            exit 1
+          fi
+          case "${{ matrix.arch }}" in
+            armhf) target="wlanpi/dev/raspbian/${{ matrix.distro }}" ;;
+            *)     target="wlanpi/dev/debian/${{ matrix.distro }}" ;;
+          esac
+          sudo gem install package_cloud
+          echo "Pushing ${DEB_PACKAGE} to ${target}"
+          out=$(package_cloud push "${target}" "${DEB_PACKAGE}" 2>&1) || true
+          echo "${out}"
+          echo "${out}" | grep -q "success!"
 
   slack-workflow-status:
     if: always()


### PR DESCRIPTION
Part of the org-wide actions audit. Two things:

1. Bumps outdated actions to current majors (checkout v7, upload-artifact v7) to clear the Node 20 deprecation warnings.
2. Recovers the workflow hardening that was stranded when the earlier trixie PR merged before the follow-up commit landed: the deploy now pushes with the package_cloud CLI directly and verifies each push reports success. The CLI exits 0 on errors (Thor bug), which has produced green deploys in this org that uploaded nothing. Also fails when sbuild produces no .deb.

Workflow YAML validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
