### PR TITLE
README: note this package is specifically for the WLAN Pi Go

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # wlanpi-usb-ethernet
 
-This package configures a USB Ethernet gadget on the WLAN Pi, providing CDC ECM (usb0) and RNDIS (usb1) interfaces for Ethernet-over-USB connectivity. It includes an integrated setup and keep-alive system to initialize the gadget and monitor connectivity, resetting when necessary.
+> **Scope: this package is specifically for the WLAN Pi Go.** It is installed by the Go (lite) image only. Other WLAN Pi devices and the full image do not use it.
+
+This package configures a USB Ethernet gadget on the WLAN Pi Go, providing CDC ECM (usb0) and RNDIS (usb1) interfaces for Ethernet-over-USB connectivity. It includes an integrated setup and keep-alive system to initialize the gadget and monitor connectivity, resetting when necessary.
 
 ## Intended Hosts
 


### PR DESCRIPTION
Documents that wlanpi-usb-ethernet is scoped to the WLAN Pi Go: it is installed by the Go (lite) image only, and the full image does not use it (removed there in WLAN-Pi/pi-gen-bookworm#117).

🤖 Generated with [Claude Code](https://claude.com/claude-code)