### PR TITLE
postinst: additive avahi edits, stop forcing publish-hinfo=no

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+wlanpi-usb-ethernet (1.5.2) bookworm; urgency=medium
+
+  * postinst: make avahi allow-interfaces edits additive instead of
+    replacing the whole line, which dropped eth0/wlan1 from mDNS on
+    every upgrade
+  * postinst: stop forcing publish-hinfo=no, which overrode the image
+    overlay setting on upgrades
+
+ -- Josh Schmelzle <josh@joshschmelzle.com>  Fri, 10 Jul 2026 16:37:03 -0400
+
 wlanpi-usb-ethernet (1.5.1) bookworm; urgency=medium
 
   * Rebuild to publish packages for Debian trixie to packagecloud

--- a/debian/postinst
+++ b/debian/postinst
@@ -51,23 +51,21 @@ if [ -f "/etc/systemd/system/usb-gadget.service" ]; then
     systemctl disable usb-gadget.service || true
 fi
 
-# Update /etc/avahi/avahi-daemon.conf for USB Ethernet
+# Update /etc/avahi/avahi-daemon.conf for USB Ethernet.
+# Additive only: if a whitelist exists, make sure the gadget interfaces
+# are on it without removing anything else (the image overlay manages
+# the full list, including eth0/wlan1). If no whitelist exists, avahi
+# already announces on all interfaces, so there is nothing to do.
+# This script must not touch unrelated settings such as publish-hinfo.
 AVAHI_CONF="/etc/avahi/avahi-daemon.conf"
 if [ -f "$AVAHI_CONF" ]; then
-    echo "Updating $AVAHI_CONF for USB Ethernet"
-
-    # Insert or update "allow-interfaces=usb0,usb1,wlan0,pan0"
     if grep -q '^allow-interfaces=' "$AVAHI_CONF"; then
-        sed -i 's/^allow-interfaces=.*/allow-interfaces=usb0,usb1,wlan0,pan0/' "$AVAHI_CONF"
-    else
-        sed -i '/^\[server\]/a allow-interfaces=usb0,usb1,wlan0,pan0' "$AVAHI_CONF"
-    fi
-
-    # Insert or update "publish-hinfo=no"
-    if grep -q '^publish-hinfo=' "$AVAHI_CONF"; then
-        sed -i 's/^publish-hinfo=.*/publish-hinfo=no/' "$AVAHI_CONF"
-    else
-        sed -i '/^\[server\]/a publish-hinfo=no' "$AVAHI_CONF"
+        for iface in usb0 usb1; do
+            if ! grep '^allow-interfaces=' "$AVAHI_CONF" | grep -qw "$iface"; then
+                echo "Adding $iface to allow-interfaces in $AVAHI_CONF"
+                sed -i "s/^allow-interfaces=.*/&, $iface/" "$AVAHI_CONF"
+            fi
+        done
     fi
 else
     echo "Warning: $AVAHI_CONF not found; unable to configure Avahi for USB Ethernet."


### PR DESCRIPTION
Follow-up to the org avahi audit and the discoverability decision in WLAN-Pi/pi-gen-bookworm#116.

The postinst avahi block ran on every install and upgrade and:

- replaced the entire `allow-interfaces` line with the hardcoded list `usb0,usb1,wlan0,pan0`, silently dropping eth0 and wlan1 from mDNS announcements on the Go image
- force-rewrote `publish-hinfo=no`, which would undo the HINFO publishing the image overlay now enables

Changes:

- Additive only: if an `allow-interfaces` whitelist already exists, ensure `usb0`/`usb1` are on it without removing anything. If no whitelist exists, do nothing, since avahi announces on all interfaces by default and inserting one would restrict announcements.
- Drop the `publish-hinfo` handling entirely. That setting belongs to the image overlay (or the admin), not this package.
- Bump to 1.5.2 so merging deploys the fixed package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)