### PR TITLE
CI: bump actions to Node 24 versions

### DIFF
--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -42,7 +42,7 @@ jobs:
 
       # 2) Check out repository (for manual runs, checkout the specified branch).
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.branch || github.ref }}
 
@@ -89,7 +89,7 @@ jobs:
 
       # 6) Upload artifact
       - name: Upload Debian package
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           # The artifact name includes the generated version (with the branch)
           name: wlanpi-usb-ethernet_${{ env.new_version }}

--- a/.github/workflows/deploy-to-packagecloud.yml
+++ b/.github/workflows/deploy-to-packagecloud.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: sbuild for ${{ matrix.distro }} ${{ matrix.arch }}
         uses: wlan-pi/sbuild-debian-package@main
@@ -36,7 +36,7 @@ jobs:
           arch: ${{ matrix.arch }}
 
       - name: Archive artifacts and upload to GitHub
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wlanpi-usb-ethernet-${{ matrix.distro }}-${{ matrix.arch }}
           path: ${{ steps.build-debian-package.outputs.deb-package }}


### PR DESCRIPTION
GitHub is [deprecating Node 20](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) on Actions runners.

This repo pinned `actions/checkout@v3` (Node 16) and `actions/checkout@v4` / `actions/upload-artifact@v4` (Node 20). Bumps all to `@v7` (Node 24) across `build-deb.yml` and `deploy-to-packagecloud.yml`. No behavior change.